### PR TITLE
Add Hytale Character Recipes resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Orbis is the ultimate community hub for Hytale, inspired by SpigotMC/CurseForge for Minecraft. The project is community-driven and open-source, reflecting Hytale's philosophy.
 
+
+## Related Hytale Resources
+
+- [Hytale Character Recipes](https://hytalecharacter.com/) - Fan-maintained character recipe archive with manual recreation notes, source screenshots, and recipe JSON for Hytale-inspired character looks.
+
 ## What's inside?
 
 This Turborepo monorepo includes the following packages & apps:


### PR DESCRIPTION
Adds Hytale Character Recipes as a related Hytale resource.

The site is a fan-maintained archive of character recreation notes, source screenshots, and recipe JSON for Hytale-inspired character looks. This is intended as a small discoverability link for players and creators who use community Hytale tooling.

Target: https://hytalecharacter.com/